### PR TITLE
Added openswoole extension check compatibility

### DIFF
--- a/src/Commands/HttpServerCommand.php
+++ b/src/Commands/HttpServerCommand.php
@@ -370,7 +370,7 @@ class HttpServerCommand extends Command
             exit(1);
         }
 
-        if (! extension_loaded('swoole')) {
+        if (! extension_loaded('swoole') && ! extension_loaded('openswoole')) {
             $this->error('Can\'t detect Swoole extension installed.');
 
             exit(1);


### PR DESCRIPTION
Swoole now became `openswoole`, from version 4.7.2 swoole extension changed as openswoole. For this reason, this package can not detect the extension and shows the message *Can't detect Swoole extension installed.* This commit fixed the issue.